### PR TITLE
Add page pre-loader

### DIFF
--- a/att-website/src/App.vue
+++ b/att-website/src/App.vue
@@ -51,7 +51,7 @@ watch(isLoading, (loading) => {
   display: flex;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 0, 0, 0.85);
+  background: #000000;
   z-index: 9999;
   transition: opacity 120ms ease-in-out;
 }

--- a/att-website/src/App.vue
+++ b/att-website/src/App.vue
@@ -1,8 +1,9 @@
 <script setup>
-import { ref, onMounted } from 'vue'
+import { ref, onMounted, watch } from 'vue'
 import { RouterView, useRouter } from 'vue-router'
 import HeaderSec from './components/Header.vue'
 import FooterSec from './components/Footer.vue'
+import logoUrl from './assets/logo.svg'
 
 const isLoading = ref(true)
 const router = useRouter()
@@ -28,13 +29,16 @@ onMounted(() => {
     isLoading.value = false
   })
 })
+
+watch(isLoading, (loading) => {
+  document.body.style.overflow = loading ? 'hidden' : ''
+})
 </script>
 
 <template>
   <HeaderSec />
   <div v-if="isLoading" class="global-loader" role="status" aria-live="polite" aria-busy="true">
-    <div class="loader-spinner"></div>
-    <span class="visually-hidden">Loading</span>
+    <img :src="logoUrl" alt="Loading" class="loader-logo" />
   </div>
   <RouterView />
   <FooterSec />
@@ -52,19 +56,11 @@ onMounted(() => {
   transition: opacity 120ms ease-in-out;
 }
 
-.loader-spinner {
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: 4px solid rgba(255, 255, 255, 0.15);
-  border-top-color: #0073AA;
-  animation: spin 0.8s linear infinite;
-  box-shadow: 0 0 12px rgba(0, 115, 170, 0.35);
-}
-
-@keyframes spin {
-  from { transform: rotate(0deg); }
-  to { transform: rotate(360deg); }
+.loader-logo {
+  width: 140px;
+  height: auto;
+  opacity: 0.95;
+  filter: drop-shadow(0 4px 18px rgba(0, 0, 0, 0.5));
 }
 
 .visually-hidden {

--- a/att-website/src/App.vue
+++ b/att-website/src/App.vue
@@ -1,15 +1,81 @@
 <script setup>
-import { RouterView } from 'vue-router'
+import { ref, onMounted } from 'vue'
+import { RouterView, useRouter } from 'vue-router'
 import HeaderSec from './components/Header.vue'
 import FooterSec from './components/Footer.vue'
+
+const isLoading = ref(true)
+const router = useRouter()
+
+router.beforeEach((_to, _from, next) => {
+  isLoading.value = true
+  next()
+})
+
+router.afterEach(() => {
+  // Small delay to avoid flicker on super fast routes
+  setTimeout(() => {
+    isLoading.value = false
+  }, 150)
+})
+
+router.onError(() => {
+  isLoading.value = false
+})
+
+onMounted(() => {
+  router.isReady().then(() => {
+    isLoading.value = false
+  })
+})
 </script>
 
 <template>
   <HeaderSec />
+  <div v-if="isLoading" class="global-loader" role="status" aria-live="polite" aria-busy="true">
+    <div class="loader-spinner"></div>
+    <span class="visually-hidden">Loading</span>
+  </div>
   <RouterView />
   <FooterSec />
 </template>
 
 <style scoped>
+.global-loader {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0, 0, 0, 0.85);
+  z-index: 9999;
+  transition: opacity 120ms ease-in-out;
+}
 
+.loader-spinner {
+  width: 48px;
+  height: 48px;
+  border-radius: 50%;
+  border: 4px solid rgba(255, 255, 255, 0.15);
+  border-top-color: #0073AA;
+  animation: spin 0.8s linear infinite;
+  box-shadow: 0 0 12px rgba(0, 115, 170, 0.35);
+}
+
+@keyframes spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
 </style>


### PR DESCRIPTION
Add a global dark-themed pre-loader to display during initial page load and route navigation, matching the website's aesthetic.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8bc2409-5377-4366-8583-874589385ac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a8bc2409-5377-4366-8583-874589385ac4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

